### PR TITLE
fix path for tarball extraction

### DIFF
--- a/.github/workflows/vanilla_k8s_postsubmits.yaml
+++ b/.github/workflows/vanilla_k8s_postsubmits.yaml
@@ -29,8 +29,8 @@ jobs:
       - name: Get kfctl
         run: |
           wget -O kfctl_v1.1.0.tar.gz https://github.com/kubeflow/kfctl/releases/download/v1.1.0/kfctl_v1.1.0-0-g9a3621e_linux.tar.gz
-          tar -zxvf kfctl_v1.1.0.tar.gz
-          echo "::add-path::kfctl"
+          tar -zxvf kfctl_v1.1.0.tar.gz -C kfctl/
+          echo "::add-path::kfctl/kfctl"
       # Create a k8s cluster with KinD
       - name: Setup KinD cluster
         uses: engineerd/setup-kind@v0.4.0
@@ -61,8 +61,8 @@ jobs:
       - name: Get kfctl
         run: |
           wget -O kfctl_v1.1.0.tar.gz https://github.com/kubeflow/kfctl/releases/download/v1.1.0/kfctl_v1.1.0-0-g9a3621e_linux.tar.gz
-          tar -zxvf kfctl_v1.1.0.tar.gz
-          echo "::add-path::kfctl"
+          tar -zxvf kfctl_v1.1.0.tar.gz -C kfctl/
+          echo "::add-path::kfctl/kfctl"
       # Create a k8s cluster with KinD
       - name: Setup KinD cluster
         uses: engineerd/setup-kind@v0.4.0


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
